### PR TITLE
Escape backspace character in logback

### DIFF
--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
@@ -46,7 +46,7 @@ public class Utils {
 	/**
 	 * Converts an input byte array to a hex encoded String.
 	 *
-	 * @param input
+	 * @param hash
 	 *            Byte array to hex encode
 	 * @return Hex encoded String of the input byte array
 	 */
@@ -84,7 +84,7 @@ public class Utils {
 	}
 
 	/**
-	 * Replace any NLF (newline function) with an underscore to prevent log injection attacks.
+	 * Escape any NLF (newline function) and Backspace to prevent log injection attacks.
 	 *
 	 * @param value
 	 *            string to convert
@@ -103,7 +103,8 @@ public class Utils {
 			// LS
 			.replace("\u2028", "\\u2028")
 			// PS
-			.replace("\u2029", "\\u2029");
+			.replace("\u2029", "\\u2029")
+			.replace("\b", "\\b");
 	}
 
 }

--- a/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
+++ b/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
@@ -29,6 +29,7 @@ public class UtilsTest {
 		Assert.assertEquals("line0\\u000Cline1", Utils.escapeNLFChars("line0\u000Cline1"));
 		Assert.assertEquals("line0\\u2028line1", Utils.escapeNLFChars("line0\u2028line1"));
 		Assert.assertEquals("line0\\u2029line1", Utils.escapeNLFChars("line0\u2029line1"));
+		Assert.assertEquals("line0\\bline1", Utils.escapeNLFChars("line0\bline1"));
 	}
 
 }

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFConverter.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFConverter.java
@@ -5,7 +5,7 @@ import ch.qos.logback.core.pattern.CompositeConverter;
 import org.owasp.security.logging.Utils;
 
 /**
- * This converter is used to encode any carriage returns and line feeds to
+ * This converter is used to encode any carriage returns, line feeds and backspaces to
  * prevent log injection attacks
  *
  * It is not possible to replace the actual formatted message, instead this


### PR DESCRIPTION
#75 Escape backspace character in logback

Updated escapeNLFChars method to escape backspace character as well.

Haven't renamed the method and converter class to not introduce a breaking change.