### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ byUser/access.log
 /.idea/
 *.iml
 NOTES.txt
+*.factorypath

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx2048m -Xms1024m --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED

--- a/owasp-security-logging-common/pom.xml
+++ b/owasp-security-logging-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>security-logging</artifactId>
     <groupId>org.owasp</groupId>
-    <version>1.1.7</version>
+    <version>1.2.0-develop</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>security-logging-common</artifactId>

--- a/owasp-security-logging-common/pom.xml
+++ b/owasp-security-logging-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>security-logging</artifactId>
     <groupId>org.owasp</groupId>
-    <version>1.2.0-develop</version>
+    <version>1.2.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>security-logging-common</artifactId>

--- a/owasp-security-logging-common/pom.xml
+++ b/owasp-security-logging-common/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/IPlugin.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/IPlugin.java
@@ -1,7 +1,7 @@
 package org.owasp.security.logging.mdc;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * This interface defines a plugin to the MDC filter. Applications can implement

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/MDCFilter.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/MDCFilter.java
@@ -5,17 +5,17 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-
 import org.owasp.security.logging.mdc.plugins.IPAddressPlugin;
 import org.owasp.security.logging.mdc.plugins.SessionPlugin;
 import org.slf4j.MDC;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * J2EE filter to add request information to the logging context. Adding data to

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/ForwardedIPAddressPlugin.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/ForwardedIPAddressPlugin.java
@@ -1,11 +1,11 @@
 package org.owasp.security.logging.mdc.plugins;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
-
 import org.owasp.security.logging.mdc.IPlugin;
 import org.owasp.security.logging.mdc.MDCFilter;
 import org.slf4j.MDC;
+
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * This plugin adds the request's remote IP address to the MDC by using the

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/IPAddressPlugin.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/IPAddressPlugin.java
@@ -1,11 +1,11 @@
 package org.owasp.security.logging.mdc.plugins;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
-
 import org.owasp.security.logging.mdc.IPlugin;
 import org.owasp.security.logging.mdc.MDCFilter;
 import org.slf4j.MDC;
+
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * This plugin adds the request's remote IP address to the MDC in the most basic

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/SessionPlugin.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/SessionPlugin.java
@@ -1,12 +1,12 @@
 package org.owasp.security.logging.mdc.plugins;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
 import org.owasp.security.logging.Utils;
 import org.owasp.security.logging.mdc.IPlugin;
 import org.slf4j.MDC;
+
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * This plugin adds a hash of the session ID to the MDC. The value can be

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/UsernamePlugin.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/mdc/plugins/UsernamePlugin.java
@@ -1,12 +1,12 @@
 package org.owasp.security.logging.mdc.plugins;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
 import org.owasp.security.logging.mdc.IPlugin;
 import org.owasp.security.logging.mdc.MDCFilter;
 import org.slf4j.MDC;
+
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * This is an example MDC plugin that gets a username from the HTTP session and

--- a/owasp-security-logging-log4j/pom.xml
+++ b/owasp-security-logging-log4j/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>security-logging</artifactId>
     <groupId>org.owasp</groupId>
-    <version>1.1.7</version>
+    <version>1.2.0-develop</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>security-logging-log4j</artifactId>
@@ -73,7 +73,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/owasp-security-logging-log4j/pom.xml
+++ b/owasp-security-logging-log4j/pom.xml
@@ -31,7 +31,7 @@
     <url>https://github.com/javabeanz/owasp-security-logging</url>
   </scm>
   <properties>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.20.0</log4j2.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -41,6 +41,11 @@
         <version>${log4j2.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-test</artifactId>
+        <version>5.3.29</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -56,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -74,14 +79,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
-      <type>test-jar</type>
+      <artifactId>log4j-core-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/owasp-security-logging-log4j/pom.xml
+++ b/owasp-security-logging-log4j/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>security-logging</artifactId>
     <groupId>org.owasp</groupId>
-    <version>1.2.0-develop</version>
+    <version>1.2.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>security-logging-log4j</artifactId>

--- a/owasp-security-logging-log4j/pom.xml
+++ b/owasp-security-logging-log4j/pom.xml
@@ -42,11 +42,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-test</artifactId>
-        <version>5.3.29</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -84,6 +79,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>5.3.29</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/owasp-security-logging-log4j/src/main/java/org/owasp/security/logging/log4j/filter/ExcludeClassifiedMarkerFilter.java
+++ b/owasp-security-logging-log4j/src/main/java/org/owasp/security/logging/log4j/filter/ExcludeClassifiedMarkerFilter.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.slf4j.Log4jMarker;
 import org.apache.logging.slf4j.Log4jMarkerFactory;
 import org.owasp.security.logging.SecurityMarkers;
 
@@ -94,8 +93,7 @@ public class ExcludeClassifiedMarkerFilter extends AbstractFilter {
 			return Result.NEUTRAL;
 		}
 
-		org.apache.logging.slf4j.Log4jMarker slf4jMarker = new Log4jMarker(
-				marker);
+		org.slf4j.Marker slf4jMarker = factory.getMarker(marker.getName());
 		for (org.slf4j.Marker matcher : markersToMatch) {
 			if (slf4jMarker.contains(matcher.getName())) {
 				return Result.DENY;

--- a/owasp-security-logging-log4j/src/main/java/org/owasp/security/logging/log4j/filter/SecurityMarkerFilter.java
+++ b/owasp-security-logging-log4j/src/main/java/org/owasp/security/logging/log4j/filter/SecurityMarkerFilter.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.slf4j.Log4jMarker;
 import org.apache.logging.slf4j.Log4jMarkerFactory;
 import org.owasp.security.logging.SecurityMarkers;
 
@@ -90,8 +89,7 @@ public class SecurityMarkerFilter extends AbstractFilter {
 			return Result.NEUTRAL;
 		}
 
-		org.apache.logging.slf4j.Log4jMarker slf4jMarker = new Log4jMarker(
-				marker);
+		org.slf4j.Marker slf4jMarker = factory.getMarker(marker.getName());
 		for (org.slf4j.Marker matcher : markersToMatch) {
 			if (slf4jMarker.contains(matcher.getName())) {
 				return Result.ACCEPT;

--- a/owasp-security-logging-log4j/src/main/java/org/owasp/security/logging/log4j/mask/MaskingRewritePolicy.java
+++ b/owasp-security-logging-log4j/src/main/java/org/owasp/security/logging/log4j/mask/MaskingRewritePolicy.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.slf4j.Log4jMarker;
+import org.apache.logging.slf4j.Log4jMarkerFactory;
 import org.owasp.security.logging.SecurityMarkers;
 
 /**
@@ -32,6 +32,8 @@ import org.owasp.security.logging.SecurityMarkers;
 public class MaskingRewritePolicy implements RewritePolicy {
 
 	public static final Object MASKED_PASSWORD = "********";
+	
+	static final Log4jMarkerFactory factory = new Log4jMarkerFactory();
 
 	@PluginFactory
 	public static MaskingRewritePolicy createPolicy() {
@@ -68,7 +70,7 @@ public class MaskingRewritePolicy implements RewritePolicy {
 
 		// check if this event is actually marked as confidential. If not,
 		// return
-		Log4jMarker eventMarker = new Log4jMarker(sourceMarker);
+		org.slf4j.Marker eventMarker = factory.getMarker(sourceMarker.getName());
 		if (!eventMarker.contains(SecurityMarkers.CONFIDENTIAL)) {
 			return source;
 		}

--- a/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/ExcludeClassifiedMarkerFilterTest.java
+++ b/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/ExcludeClassifiedMarkerFilterTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.junit.LoggerContextRule;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/PureLog4jTest.java
+++ b/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/PureLog4jTest.java
@@ -13,8 +13,8 @@
  */
 package org.owasp.security.logging.log4j;
 
-import org.apache.logging.log4j.junit.LoggerContextRule;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/SecurityMarkerFilterTest.java
+++ b/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/SecurityMarkerFilterTest.java
@@ -19,8 +19,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.junit.LoggerContextRule;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/mask/CRLFConverterTest.java
+++ b/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/mask/CRLFConverterTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/mask/CRLFConverterTest.java
+++ b/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/mask/CRLFConverterTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.pattern.EncodingPatternConverter;
-import org.apache.logging.log4j.junit.LoggerContextRule;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/mask/MaskingRewritePolicyTest.java
+++ b/owasp-security-logging-log4j/src/test/java/org/owasp/security/logging/log4j/mask/MaskingRewritePolicyTest.java
@@ -1,15 +1,16 @@
 package org.owasp.security.logging.log4j.mask;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessageFactory;
-import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/owasp-security-logging-logback/pom.xml
+++ b/owasp-security-logging-logback/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>security-logging</artifactId>
     <groupId>org.owasp</groupId>
-    <version>1.1.7</version>
+    <version>1.2.0-develop</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>security-logging-logback</artifactId>
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/owasp-security-logging-logback/pom.xml
+++ b/owasp-security-logging-logback/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>security-logging</artifactId>
     <groupId>org.owasp</groupId>
-    <version>1.2.0-develop</version>
+    <version>1.2.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>security-logging-logback</artifactId>

--- a/owasp-security-logging-logback/pom.xml
+++ b/owasp-security-logging-logback/pom.xml
@@ -31,7 +31,7 @@
     <url>https://github.com/javabeanz/owasp-security-logging</url>
   </scm>
   <properties>
-    <logback.version>1.2.8</logback.version>
+    <logback.version>1.4.9</logback.version>
   </properties>
   <dependencies>
     <dependency>
@@ -75,8 +75,8 @@
       <version>1.13</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/layout/rich/RichMDCFilter.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/layout/rich/RichMDCFilter.java
@@ -1,8 +1,7 @@
 package org.owasp.security.logging.layout.rich;
 
-import javax.servlet.ServletRequest;
-
 import ch.qos.logback.classic.helpers.MDCInsertingServletFilter;
+import jakarta.servlet.ServletRequest;
 
 public class RichMDCFilter extends MDCInsertingServletFilter {
 

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFThrowableProxy.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFThrowableProxy.java
@@ -56,4 +56,9 @@ public class CRLFThrowableProxy implements IThrowableProxy {
     public IThrowableProxy[] getSuppressed() {
         return proxied.getSuppressed();
     }
+
+	@Override
+	public boolean isCyclic() {
+		return proxied.isCyclic();
+	}
 }

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFThrowableProxy.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFThrowableProxy.java
@@ -56,4 +56,9 @@ public class NLFThrowableProxy implements IThrowableProxy {
 	public IThrowableProxy[] getSuppressed() {
 		return proxied.getSuppressed();
 	}
+
+	@Override
+	public boolean isCyclic() {
+		return proxied.isCyclic();
+	}
 }

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/SecurityMarkersTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/SecurityMarkersTest.java
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/SecurityTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/SecurityTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Logger;

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/ExcludeClassifiedMarkerFilterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/ExcludeClassifiedMarkerFilterTest.java
@@ -185,27 +185,27 @@ public class ExcludeClassifiedMarkerFilterTest {
 
 		// test a logging event with the CONFIDENTIAL marker
 		LoggingEvent confidentialEvent = new LoggingEvent();
-		confidentialEvent.setMarker(SecurityMarkers.CONFIDENTIAL);
+		confidentialEvent.addMarker(SecurityMarkers.CONFIDENTIAL);
 		assertEquals(FilterReply.DENY, mkt.decide(confidentialEvent));
 
 		// test a logging event with the RESTRICTED marker
 		LoggingEvent restrictedEvent = new LoggingEvent();
-		restrictedEvent.setMarker(SecurityMarkers.RESTRICTED);
+		restrictedEvent.addMarker(SecurityMarkers.RESTRICTED);
 		assertEquals(FilterReply.DENY, mkt.decide(restrictedEvent));
 
 		// test a logging event with the SECRET marker
 		LoggingEvent secretEvent = new LoggingEvent();
-		secretEvent.setMarker(SecurityMarkers.SECRET);
+		secretEvent.addMarker(SecurityMarkers.SECRET);
 		assertEquals(FilterReply.DENY, mkt.decide(secretEvent));
 
 		// test a logging event with the TOP_SECRET marker
 		LoggingEvent topSecretEvent = new LoggingEvent();
-		topSecretEvent.setMarker(SecurityMarkers.TOP_SECRET);
+		topSecretEvent.addMarker(SecurityMarkers.TOP_SECRET);
 		assertEquals(FilterReply.DENY, mkt.decide(topSecretEvent));
 
 		// test a logging event without the CONFIDENTIAL marker
 		LoggingEvent normalEvent = new LoggingEvent();
-		normalEvent.setMarker(SecurityMarkers.EVENT_SUCCESS);
+		normalEvent.addMarker(SecurityMarkers.EVENT_SUCCESS);
 		assertEquals(FilterReply.NEUTRAL, mkt.decide(nulEvent));
 	}
 }

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/ExcludeClassifiedMarkerFilterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/ExcludeClassifiedMarkerFilterTest.java
@@ -20,7 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import static org.mockito.Mockito.verify;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Marker;
 
 /**

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/MarkerFilterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/MarkerFilterTest.java
@@ -34,12 +34,12 @@ public class MarkerFilterTest {
 
 		// test a logging event with the CONFIDENTIAL marker
 		LoggingEvent confidentialEvent = new LoggingEvent();
-		confidentialEvent.setMarker(SecurityMarkers.CONFIDENTIAL);
+		confidentialEvent.addMarker(SecurityMarkers.CONFIDENTIAL);
 		assertEquals(FilterReply.ACCEPT, mkt.decide(confidentialEvent));
 
 		// test a logging event without the CONFIDENTIAL marker
 		LoggingEvent normalEvent = new LoggingEvent();
-		normalEvent.setMarker(SecurityMarkers.EVENT_SUCCESS);
+		normalEvent.addMarker(SecurityMarkers.EVENT_SUCCESS);
 		assertEquals(FilterReply.DENY, mkt.decide(nulEvent));
 
 		Logger LOGGER = lc.getLogger(MarkerFilterTest.class);

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/SecurityMarkerFilterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/SecurityMarkerFilterTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/SecurityMarkerFilterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/filter/SecurityMarkerFilterTest.java
@@ -174,17 +174,17 @@ public class SecurityMarkerFilterTest {
 
 		// test a logging event with the CONFIDENTIAL marker
 		LoggingEvent confidentialEvent = new LoggingEvent();
-		confidentialEvent.setMarker(SecurityMarkers.SECURITY_SUCCESS);
+		confidentialEvent.addMarker(SecurityMarkers.SECURITY_SUCCESS);
 		assertEquals(FilterReply.NEUTRAL, mkt.decide(confidentialEvent));
 
 		// test a logging event with the RESTRICTED marker
 		LoggingEvent restrictedEvent = new LoggingEvent();
-		restrictedEvent.setMarker(SecurityMarkers.SECURITY_FAILURE);
+		restrictedEvent.addMarker(SecurityMarkers.SECURITY_FAILURE);
 		assertEquals(FilterReply.NEUTRAL, mkt.decide(restrictedEvent));
 
 		// test a logging event with the SECRET marker
 		LoggingEvent secretEvent = new LoggingEvent();
-		secretEvent.setMarker(SecurityMarkers.SECURITY_AUDIT);
+		secretEvent.addMarker(SecurityMarkers.SECURITY_AUDIT);
 		assertEquals(FilterReply.NEUTRAL, mkt.decide(secretEvent));
 	}
 
@@ -204,17 +204,17 @@ public class SecurityMarkerFilterTest {
 
 		// test a logging event with the CONFIDENTIAL marker
 		LoggingEvent confidentialEvent = new LoggingEvent();
-		confidentialEvent.setMarker(SecurityMarkers.SECURITY_SUCCESS);
+		confidentialEvent.addMarker(SecurityMarkers.SECURITY_SUCCESS);
 		assertEquals(FilterReply.ACCEPT, mkt.decide(confidentialEvent));
 
 		// test a logging event with the RESTRICTED marker
 		LoggingEvent restrictedEvent = new LoggingEvent();
-		restrictedEvent.setMarker(SecurityMarkers.SECURITY_FAILURE);
+		restrictedEvent.addMarker(SecurityMarkers.SECURITY_FAILURE);
 		assertEquals(FilterReply.ACCEPT, mkt.decide(restrictedEvent));
 
 		// test a logging event with the SECRET marker
 		LoggingEvent secretEvent = new LoggingEvent();
-		secretEvent.setMarker(SecurityMarkers.SECURITY_AUDIT);
+		secretEvent.addMarker(SecurityMarkers.SECURITY_AUDIT);
 		assertEquals(FilterReply.ACCEPT, mkt.decide(secretEvent));
 	}
 

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFConverterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFConverterTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 
 import static org.mockito.Mockito.verify;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFThrowableConverterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFThrowableConverterTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/MaskingConverterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/MaskingConverterTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 
 import static org.mockito.Mockito.verify;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/SSNMaskingConverterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/SSNMaskingConverterTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SSNMaskingConverterTest extends BaseConverterTest {

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/util/StreamRedirectionWithCustomLoggersTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/util/StreamRedirectionWithCustomLoggersTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </developers>
   <modules>
     <module>owasp-security-logging-common</module>
-<!--    <module>owasp-security-logging-log4j</module>-->
+    <module>owasp-security-logging-log4j</module>
     <module>owasp-security-logging-logback</module>
   </modules>
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <!-- Top-level Parent POM -->
   <groupId>org.owasp</groupId>
   <artifactId>security-logging</artifactId>
-  <version>1.2.0-develop</version>
+  <version>1.2.0</version>
   <packaging>pom</packaging>
   <name>OWASP Security Logging</name>
   <description>The OWASP Security Logging project provides developers and ops personnel with APIs for logging security-related events.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </developers>
   <modules>
     <module>owasp-security-logging-common</module>
-    <module>owasp-security-logging-log4j</module>
+<!--    <module>owasp-security-logging-log4j</module>-->
     <module>owasp-security-logging-logback</module>
   </modules>
   <scm>
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.25</version>
+        <version>2.0.7</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -62,9 +62,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>3.0.1</version>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>5.0.0</version>
         <scope>provided</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <!-- Top-level Parent POM -->
   <groupId>org.owasp</groupId>
   <artifactId>security-logging</artifactId>
-  <version>1.1.7</version>
+  <version>1.2.0-develop</version>
   <packaging>pom</packaging>
   <name>OWASP Security Logging</name>
   <description>The OWASP Security Logging project provides developers and ops personnel with APIs for logging security-related events.</description>
@@ -51,8 +51,8 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.10.19</version>
+        <artifactId>mockito-core</artifactId>
+        <version>5.4.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -75,10 +75,10 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.11.0</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
       </plugins>
@@ -87,7 +87,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.5</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
SLF4J API updated to 2.0.x
Switch to Jakarta Servlet 5.0 API (javax.servlet to jakarta.servlet)
Change the dependency in the security-logging-log4j module to log4j-slf4j2-impl (min. version required for this change 2.19.0)
Some refactoring in security-logging-log4j because Log4jMarker is not a public class anymore since 2.19.0 and packages changed for some test classes